### PR TITLE
Install certbot and use it to get certificate

### DIFF
--- a/letsencrypt/config.sls
+++ b/letsencrypt/config.sls
@@ -4,11 +4,11 @@ include:
   - .install
   - .service
 
-{%- if letsencrypt.get('staging', false) %}
-{%-   set staging = '--staging' %}
-{%- else %}
-{%-   set staging = '' %}
-{%- endif %}
+{% if letsencrypt.get('staging', false) %}
+{% set staging = '--staging' %}
+{% else %}
+{% set staging = '' %}
+{% endif %}
 
 generate_certbot_{{ letsencrypt.CN }}:
   cmd.run:

--- a/letsencrypt/config.sls
+++ b/letsencrypt/config.sls
@@ -4,12 +4,24 @@ include:
   - .install
   - .service
 
-letsencrypt-config:
-  file.managed:
-    - name: {{ letsencrypt.conf_file }}
-    - source: salt://letsencrypt/templates/conf.jinja
-    - template: jinja
-    - watch_in:
-      - service: letsencrypt_service_running
+{%- if letsencrypt.get('staging', false) %}
+{%-   set staging = '--staging' %}
+{%- else %}
+{%-   set staging = '' %}
+{%- endif %}
+
+generate_certbot_{{ letsencrypt.CN }}:
+  cmd.run:
+    - name: >
+        certbot --authenticator webroot -w {{ letsencrypt.webroot }}
+        --installer {{ letsencrypt.webserver }} {{ staging }}
+        --non-interactive --agree-tos --email {{ letsencrypt.email }}
+        -d {{ letsencrypt.common_name }} \
+        {% for subject_alternative_name in letsencrypt.subject_alternative_names %}
+        -d {{ subject_alternative_name }} \
+        {% endfor %}
+        --expand
     - require:
-      - pkg: letsencrypt
+      - pkg: install_certbot
+    - onchanges_in:
+      - service: certbot_service_running

--- a/letsencrypt/install.sls
+++ b/letsencrypt/install.sls
@@ -1,10 +1,24 @@
 {% from "letsencrypt/map.jinja" import letsencrypt with context %}
+{% set os_family = salt.grains.get('os_family') %}
+{% set distro_codename = salt.grains.get('lsb_distrib_codename') %}
 
-include:
-  - .service
+{% if os_family == 'Debian' %}
+configure_backports_repo:
+  pkgrepo.managed:
+    - humanname: letsencrypt
+    - name: deb http://ftp.debian.org/debian {{ distro_codename }}-backports main
+    - refresh_db: True
+    - enabled: 1
 
-letsencrypt:
+install_certbot:
   pkg.installed:
-    - pkgs: {{ letsencrypt.pkgs }}
-    - require_in:
-        - service: letsencrypt_service_running
+    - name: {{ letsencrypt.pkg }}-{{ letsencrypt.webserver }}
+    - fromrepo: {{ distro_codename }}-backports
+    - require:
+        - pkgrepo: configure_backports_repo
+
+{% elif os_family == 'RedHat' %}
+install_certbot:
+  pkg.installed:
+    - name: {{ letsencrypt.pkg }}-{{ letsencrypt.webserver }}
+{% endif %}

--- a/letsencrypt/map.jinja
+++ b/letsencrypt/map.jinja
@@ -1,14 +1,18 @@
 {% set letsencrypt = salt.grains.filter_by({
     'default': {
-        'pkgs': ['letsencrypt'],
-        'service': 'letsencrypt',
-        'conf_file': '/etc/letsencrypt/letsencrypt.conf',
-        'config': {
-            'key': 'value',
-        },
+        'webserver': 'nginx',
+        'webroot': '/usr/share/nginx/html/',
+        'service': 'certbot',
+        'email': 'user@example.com',
+        'common_name': 'example.com',
+        'subject_alternative_names': [
+          'test.example.com',
+          ],
     },
     'Debian': {
+      'pkg': 'python-certbot'
     },
     'RedHat': {
+      'pkg': 'python2-certbot'
     },
 }, grain='os_family', merge=salt.pillar.get('letsencrypt:overrides'), base='default') %}

--- a/letsencrypt/service.sls
+++ b/letsencrypt/service.sls
@@ -1,6 +1,6 @@
 {% from "letsencrypt/map.jinja" import letsencrypt with context %}
 
-letsencrypt_service_running:
+certbot_service_running:
   service.running:
     - name: {{ letsencrypt.service }}
     - enable: True


### PR DESCRIPTION
Formula to leverage the use of Certbot to do the following:
- Install Certbot
- Use Certbot to get a letsencrypt certificate based on provided pillar information
- Part of the Certbot install is to also add a cron job for renewal 