### PR TITLE
Fix certbot -d option for domains

### DIFF
--- a/letsencrypt/config.sls
+++ b/letsencrypt/config.sls
@@ -10,18 +10,15 @@ include:
 {% set staging = '' %}
 {% endif %}
 
+{% set domains = [letsencrypt.common_name] + letsencrypt.subject_alternative_names %}
+
 generate_certbot_{{ letsencrypt.common_name }}:
   cmd.run:
     - name: >
         certbot --authenticator webroot -w {{ letsencrypt.webroot }}
         --installer {{ letsencrypt.webserver }} {{ staging }}
         --non-interactive --agree-tos --email {{ letsencrypt.email }}
-        -d {{ letsencrypt.common_name }} \
-        {% if letsencrypt.subject_alternative_names %}
-        {% for subject_alternative_name in letsencrypt.subject_alternative_names %}
-        -d {{ subject_alternative_name }} \
-        {% endfor %}
-        {% endif %}
+        -d {{ domains|join(',') }}
         --expand
     - require:
       - pkg: install_certbot


### PR DESCRIPTION
Fix the `-d` option that is passed to certbot to specify domains (including subject alternative names). It appears that the -d option has changed over  time, or was wrong in the formula. The certbot documentation (in `certbot --help` and online) says it should be a comma-separated list, but our formula was passing multiple `-d` options.

The invocation used currently is failing to acquire a certificate with the domains specified in `letsencrypt:overrides:subject_alternative_names`.
